### PR TITLE
Add project.el integration

### DIFF
--- a/README.org
+++ b/README.org
@@ -2,26 +2,27 @@
 
 Nameframe provides utility functions to manage frames by their names.
 
-It's primary goal is to be used with [[https://github.com/bbatsov/projectile][Projectile]] and/or [[https://github.com/nex3/perspective-el][perspective.el]]. When opening a Projectile
-project, it will either switch to an existing frame of the project, or
-create a new frame for the project.
+It's primary goal is to be used with project.el (or Projectile) and/or
+[[https://github.com/nex3/perspective-el][perspective.el]]. When opening a project, it will either switch to an
+existing frame of the project, or create a new frame for the project.
 
 ** Installation
 
 *** MELPA
 
-Nameframe is now available on [[http://melpa.org/#/?q=nameframe][MELPA]]. The Projectile and perspective.el integrations
-are distributed separately (and thus will need to be installed separately).
+Nameframe is now available on [[http://melpa.org/#/?q=nameframe][MELPA]]. The project.el and perspective.el
+integrations are distributed separately (and thus will need to be
+installed separately).
 
 - ~M-x package-install~ =RET= ~nameframe~ =RET=
-- ~M-x package-install~ =RET= ~nameframe-projectile~ =RET=
+- ~M-x package-install~ =RET= ~nameframe-project~ =RET=
 - ~M-x package-install~ =RET= ~nameframe-perspective~ =RET=
 
 *** Manual install
 
 Copy ~nameframe.el~ into your Emacs load path.
 
-Optionally, copy ~nameframe-projectile.el~ and ~nameframe-perspective.el~
+Optionally, copy ~nameframe-project.el~ and ~nameframe-perspective.el~
 into your load path as well. See *Usage* section below for details.
 
 ** Usage
@@ -32,6 +33,20 @@ into your load path as well. See *Usage* section below for details.
 |--------------------------+------------------------------------------------------------------|
 | ~nameframe-switch-frame~ | (interactive) function to switch between existing frames by name |
 | ~nameframe-create-frame~ | (interactive) function to create a new frame                     |
+
+*** Project.el
+
+Nameframe provides project.el integration to open projects in their
+own frames. To enable project.el integration, add the following line to your
+init file:
+
+#+BEGIN_SRC emacs-lisp
+(nameframe-project-mode t)
+#+END_SRC
+
+With project.el integration enabled, an =advice= is added to
+create/switch to a project's frame when switching projects with
+=project-switch-project=.
 
 *** Projectile
 
@@ -61,17 +76,16 @@ create a perspective.
 
 *** Recommended setup
 
-Although the Projectile and ~perspective.el~ integrations are optional, nameframe
+Although the ~project.el~ and ~perspective.el~ integrations are optional, nameframe
 really shines when used in conjunction with both packages. Here is a snippet on how to
 use nameframe to its full potential:
 
 #+BEGIN_SRC emacs-lisp
-;; Assuming Projectile and perspective.el are already installed
+;; Assuming project.el and perspective.el are already installed
 
-(projectile-global-mode)
 (persp-mode)
 
-(nameframe-projectile-mode t)
+(nameframe-project-mode t)
 (nameframe-perspective-mode t)
 
 ;; If your OS can't switch between applications windows by default *cough* OS X *cough*

--- a/nameframe-eyebrowse.el
+++ b/nameframe-eyebrowse.el
@@ -3,8 +3,8 @@
 ;; Author: John Del Rosario <john2x@gmail.com>, surya <surya46584@gmail.com>
 ;; URL: https://github.com/john2x/nameframe
 ;; Package-Version: 20160927.2103
-;; Version: 0.4.1-beta
-;; Package-Requires: ((nameframe "0.4.1-beta") (eyebrowse "1.12"))
+;; Version: 0.5.0-beta
+;; Package-Requires: ((nameframe "0.5.0-beta") (eyebrowse "1.12"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/nameframe-perspective.el
+++ b/nameframe-perspective.el
@@ -2,8 +2,8 @@
 
 ;; Author: John Del Rosario <john2x@gmail.com>
 ;; URL: https://github.com/john2x/nameframe
-;; Version: 0.4.2-beta
-;; Package-Requires: ((nameframe "0.4.1-beta") (perspective "1.12"))
+;; Version: 0.5.0-beta
+;; Package-Requires: ((nameframe "0.5.0-beta") (perspective "1.12"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/nameframe-project.el
+++ b/nameframe-project.el
@@ -1,0 +1,65 @@
+;;; nameframe-project.el --- Nameframe integration with project.el
+
+;; Author: John Del Rosario <john2x@gmail.com>
+;; URL: https://github.com/john2x/nameframe
+;; Version: 0.4.2-beta
+;; Package-Requires: ((nameframe "0.4.1-beta") (project "0.8.1"))
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This package defines a function to advice
+;; `project-switch-project' which will create/switch to a named frame
+;; of the target project.
+
+;; To use this library, put this file in your Emacs load path,
+;; and call (nameframe-project-mode t).
+
+;;; Code:
+
+(require 'nameframe)
+(require 'project)
+
+;;;###autoload
+(define-minor-mode nameframe-project-mode
+  "Global minor mode that creates/switches to a frame when switching projects."
+  :init-value nil
+  :lighter nil
+  :global t
+  :group 'nameframe
+  :require 'nameframe-project
+  (cond
+   (nameframe-project-mode
+    (advice-add #'project-switch-project :before #'nameframe-project-switch-project-advice))
+   (t
+    (advice-remove #'project-switch-project #'nameframe-project-switch-project-advice))))
+
+(defun nameframe-project-switch-project-advice (dir &rest args)
+  "Advice for `project-switch-project' so a frame is created for a project.
+DIR and ARGS are args for the adviced function."
+  (let* ((name (file-name-nondirectory (directory-file-name dir)))
+         (curr-frame (selected-frame))
+         (frame-alist (nameframe-frame-alist))
+         (frame (nameframe-get-frame name frame-alist)))
+    (cond
+     ;; project frame already exists
+     ((and frame (not (equal frame curr-frame)))
+      (select-frame-set-input-focus frame))
+     ((not frame)
+      (nameframe-make-frame name)))))
+
+(provide 'nameframe-project)
+
+;;; nameframe-project.el ends here

--- a/nameframe-project.el
+++ b/nameframe-project.el
@@ -2,8 +2,8 @@
 
 ;; Author: John Del Rosario <john2x@gmail.com>
 ;; URL: https://github.com/john2x/nameframe
-;; Version: 0.4.2-beta
-;; Package-Requires: ((nameframe "0.4.1-beta") (project "0.8.1"))
+;; Version: 0.5.0-beta
+;; Package-Requires: ((nameframe "0.5.0-beta") (project "0.8.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/nameframe-projectile.el
+++ b/nameframe-projectile.el
@@ -2,8 +2,8 @@
 
 ;; Author: John Del Rosario <john2x@gmail.com>
 ;; URL: https://github.com/john2x/nameframe
-;; Version: 0.4.1-beta
-;; Package-Requires: ((nameframe "0.4.1-beta") (projectile "0.13.0"))
+;; Version: 0.5.0-beta
+;; Package-Requires: ((nameframe "0.5.0-beta") (projectile "0.13.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/nameframe.el
+++ b/nameframe.el
@@ -2,7 +2,7 @@
 
 ;; Author: John Del Rosario <john2x@gmail.com>
 ;; URL: https://github.com/john2x/nameframe
-;; Version: 0.4.1-beta
+;; Version: 0.5.0-beta
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -19,11 +19,13 @@
 
 ;;; Commentary:
 
-;; This package defines utility functions for managing frames by their names.
-;; It is meant to be used together with Projectile and perspective.el.
+;; This package defines utility functions for managing frames by their
+;; names.  It is meant to be used together with Projectile (or
+;; project.el) and perspective.el.
 ;;
-;; To enable Projectile integration, call (nameframe-projectile-init).
-;; To enable perspective.el integration, call (nameframe-perspective-init).
+;; To enable Projectile integration, call (nameframe-projectile-mode).
+;; To enable project.el integration, call (nameframe-project-mode).
+;; To enable perspective.el integration, call (nameframe-perspective-mode).
 
 ;;; Code:
 


### PR DESCRIPTION
Emacs 28 comes with built-in `project.el` support. This makes Projectile unnecessary if you just need a project switcher.

Perspective is still needed for the unique buffer list per project frame though.